### PR TITLE
fix: not correct shown unsupported fields

### DIFF
--- a/src/main/java/io/camunda/connector/rabbitmq/ValidationPropertiesUtil.java
+++ b/src/main/java/io/camunda/connector/rabbitmq/ValidationPropertiesUtil.java
@@ -25,7 +25,7 @@ public final class ValidationPropertiesUtil {
               .anyMatch(f -> f.getName().equals(entry.getKey()));
       if (!fieldExist) {
         throw new IllegalArgumentException(
-            "Unsupported field '" + entry.getKey() + "' for properties");
+            "Unsupported field \'" + entry.getKey() + "\' for properties");
       }
     }
     return jsonElement;

--- a/src/test/java/io/camunda/connector/rabbitmq/ValidationPropertiesUtilTest.java
+++ b/src/test/java/io/camunda/connector/rabbitmq/ValidationPropertiesUtilTest.java
@@ -49,6 +49,6 @@ class ValidationPropertiesUtilTest extends BaseTest {
             IllegalArgumentException.class,
             () -> ValidationPropertiesUtil.validateAmqpBasicPropertiesOrThrowException(properties),
             "IllegalArgumentException was expected");
-    assertThat(thrown.getMessage()).contains("Unsupported field", "for properties");
+    assertThat(thrown.getMessage()).contains("Unsupported field '", "' for properties");
   }
 }


### PR DESCRIPTION
## Description

The error message should read as: Failed to invoke connector, received the following error: Unsupported field 'contentEnconding' for properties

## Related issues

closes #18